### PR TITLE
ForceClient: BC BREAK - port should be int instead of String

### DIFF
--- a/lib/client/force_client.dart
+++ b/lib/client/force_client.dart
@@ -2,14 +2,14 @@ part of dart_force_client_lib;
 
 class ForceClient extends ForceBaseMessageSendReceiver with ClientSendable {
   Socket socket;
-  
+
   ForceMessageDispatcher _messageDispatcher;
-  
+
   String wsPath;
-  
+
   var _profileInfo = {};
-  
-  ForceClient({String wsPath: "/ws", String url: null, String host: null, String port: null, int heartbeat: 500, bool usePolling: false}) {
+
+  ForceClient({String wsPath: "/ws", String url: null, String host: null, int port: null, int heartbeat: 500, bool usePolling: false}) {
     print("create a forceclient");
     _messageDispatcher = new ForceMessageDispatcher(this);
     this.wsPath = wsPath;
@@ -17,33 +17,33 @@ class ForceClient extends ForceBaseMessageSendReceiver with ClientSendable {
       host = '${Uri.base.host}';
     }
     if (port==null) {
-      port = '${Uri.base.port}';
+      port = Uri.base.port;
     }
     if (url==null) {
       url = '$host:$port';
     }
-    
+
     this.socket = new Socket('$url$wsPath', usePolling: usePolling, heartbeat: heartbeat);
-    
+
     this.messenger = new BrowserMessenger(socket);
   }
-  
+
   void connect() {
    this.socket.connect();
    this.socket.onMessage.listen((e) {
      _messageDispatcher.onMessagesDispatch(onInnerMessage(e.data));
    });
   }
-  
+
   void on(String request, MessageReceiver vaderMessageController) {
     _messageDispatcher.register(request, vaderMessageController);
   }
-  
+
   dynamic generateId() {
     var rng = new Random();
     return rng.nextInt(10000000);
   }
-   
+
   Stream<ConnectEvent> get onConnected =>  this.socket.onConnecting;
   Stream<ConnectEvent> get onDisconnected =>  this.socket.onDisconnecting;
 }


### PR DESCRIPTION
I didn't find any reason, why `port` should be `String` so I changed it to `int`. I found it helpful because code on client side and server side should be similar and this was big difference.

But it's big BC break.
